### PR TITLE
fix: property names in Book and Category classes

### DIFF
--- a/Library/Model/Book.cs
+++ b/Library/Model/Book.cs
@@ -1,11 +1,11 @@
 public class Book
 {
     public int Id { get; set; }
-    public string Tittle { get; set; }
+    public string Title { get; set; }
     public string Author { get; set; }
     public string ISBN { get; set; }
-    public int AñoPublicacion { get; set; }
-    public bool Disponible { get; set; }
-    public int CategoriaId { get; set; }
+    public int PublicationYear { get; set; }
+    public bool Available { get; set; }
+    public int CategoryId { get; set; }
     public Category Category { get; set; }
 }

--- a/Library/Model/Category.cs
+++ b/Library/Model/Category.cs
@@ -1,6 +1,6 @@
 public class Category
 {
     public int Id { get; set; }
-    public string Nombre { get; set; }
-    public List<Book> Libros { get; set; }
+    public string Name { get; set; }
+    public List<Book> Books { get; set; }
 }


### PR DESCRIPTION
Updated property names in the Book class for clarity:
- Corrected `Tittle` to `Title`
- Renamed `AñoPublicacion` to `PublicationYear`
- Changed `Disponible` to `Available`
- Updated `CategoriaId` to `CategoryId`

Modified the Category class to use English terminology:
- Changed `Nombre` to `Name`
- Renamed `Libros` to `Books`