### PR TITLE
feat: add Suggestions service, controller, and data seeding

### DIFF
--- a/Library/Controllers/Suggestions/SuggestionsController.cs
+++ b/Library/Controllers/Suggestions/SuggestionsController.cs
@@ -1,0 +1,27 @@
+﻿using Library.Services.Suggestions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Library.Controllers.Suggestions
+{
+    [ApiController]
+    [Route("api/suggestions")]
+    public class SuggestionsController : ControllerBase
+    {
+        private readonly ISuggestionsService _svc;
+
+        public SuggestionsController(ISuggestionsService svc)
+        {
+            _svc = svc;
+        }
+        
+        [HttpGet]
+        [Authorize]
+        public async Task<IActionResult> Get([FromQuery] int top = 10, CancellationToken ct = default)
+        {
+            var items = await _svc.SuggestionsAsync(top, ct);
+            return Ok(items);
+        }
+    }    
+}
+

--- a/Library/DTO/Suggestions/SuggestionListItem.cs
+++ b/Library/DTO/Suggestions/SuggestionListItem.cs
@@ -1,0 +1,11 @@
+﻿namespace Library.DTO.Suggestions;
+
+public class SuggestionListItem
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = default!;
+    public string Author { get; set; } = default!;
+    public string Category { get; set; } = default!;
+    public int PublicationYear { get; set; }
+    public double Score { get; set; } 
+}

--- a/Library/DTO/Suggestions/SuggestionsResponse.cs
+++ b/Library/DTO/Suggestions/SuggestionsResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace Library.DTO.Suggestions;
+
+public class SuggestionsResponse
+{
+    
+}

--- a/Library/DTO/Users/UsersRequest.cs
+++ b/Library/DTO/Users/UsersRequest.cs
@@ -1,6 +1,0 @@
-﻿namespace Library.DTO.Users;
-
-public class UsersRequest
-{
-    public Guid Id { get; set; }
-}

--- a/Library/DTO/Users/UsersResponse.cs
+++ b/Library/DTO/Users/UsersResponse.cs
@@ -1,8 +1,0 @@
-﻿namespace Library.DTO.Users;
-
-public class UsersResponse
-{
-    public Guid Id { get; set; }
-    public string Name { get; set; }
-    public string Email { get; set; }
-}

--- a/Library/Program.cs
+++ b/Library/Program.cs
@@ -1,11 +1,13 @@
 using System.Text;
 using Library.Data;
 using Library.Options;
+using Library.Seed;
 using Library.Services.Auth;
 using Library.Services.Auth.Users;
 using Library.Services.Books;
 using Library.Services.Category;
 using Library.Services.Loan;
+using Library.Services.Suggestions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -47,7 +49,7 @@ builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IBookServices, BookServices>();
 builder.Services.AddScoped<ILoanServices, LoanServices>();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
-
+builder.Services.AddScoped<ISuggestionsService, SuggestionsService>();
 
 // JWT Bearer
 var jwtSection = builder.Configuration.GetSection("Jwt");
@@ -125,6 +127,9 @@ using (var scope = app.Services.CreateScope())
             await Task.Delay(2000);
         }
     }
+    
+    DataSeeder.SeedCategories(dbCtx);
+    DataSeeder.SeedBooks(dbCtx);
 }
 
 app.Run();

--- a/Library/Seed/DataSeeder.cs
+++ b/Library/Seed/DataSeeder.cs
@@ -1,0 +1,73 @@
+﻿using Library.Data;
+using Library.Model;
+
+namespace Library.Seed;
+
+public class DataSeeder
+{
+    public static void SeedBooks(LibraryDbContext db)
+    {
+        if (db.Book.Any())
+            return;
+
+        var random = new Random();
+        var categories = db.Category.Select(c => c.Id).ToList();
+
+        if (!categories.Any())
+            throw new Exception("Unknown categories. Please seed categories first.");
+
+        var books = new List<Book>();
+
+        for (int i = 1; i <= 120; i++)
+        {
+            var categoryId = categories[random.Next(categories.Count)];
+            books.Add(new Book
+            {
+                Title = $"Book test {i}",
+                Author = $"Author {random.Next(1, 50)}",
+                ISBN = $"{random.Next(100, 999)}-{random.Next(1000, 9999)}-{random.Next(1000, 9999)}",
+                PublicationYear = random.Next(1980, 2025),
+                Available = true,
+                CategoryId = categoryId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+        }
+
+        db.Book.AddRange(books);
+        db.SaveChanges();
+    }
+    
+    public static void SeedCategories(LibraryDbContext db)
+    {
+        if (db.Category.Any())
+            return;
+
+        var categories = new List<Category>
+        {
+            new Category { Name = "Fiction" },
+            new Category { Name = "Non-Fiction" },
+            new Category { Name = "Science" },
+            new Category { Name = "History" },
+            new Category { Name = "Technology" },
+            new Category { Name = "Children's Literature" },
+            new Category { Name = "Fantasy" },
+            new Category { Name = "Mystery" },
+            new Category { Name = "Romance" },
+            new Category { Name = "Horror" },
+            new Category { Name = "Thriller" },
+            new Category { Name = "Biography" },
+            new Category { Name = "Autobiography" },
+            new Category { Name = "Poetry" },
+            new Category { Name = "Drama" },
+            new Category { Name = "Adventure" },
+            new Category { Name = "Science Fiction" },
+            new Category { Name = "Self-Help" },
+            new Category { Name = "Spirituality" },
+            new Category { Name = "Essay" }
+        };
+        
+        db.Category.AddRange(categories);
+        db.SaveChanges();
+    }
+}

--- a/Library/Services/Suggestions/ISuggestionsService.cs
+++ b/Library/Services/Suggestions/ISuggestionsService.cs
@@ -1,0 +1,12 @@
+﻿using Library.DTO.Books;
+using Library.DTO.Suggestions;
+
+namespace Library.Services.Suggestions
+{
+    public interface ISuggestionsService
+    {
+        Task<IReadOnlyList<SuggestionListItem>> SuggestionsAsync(int top = 10, CancellationToken ct = default);
+
+    }    
+}
+

--- a/Library/Services/Suggestions/SuggestionsServices.cs
+++ b/Library/Services/Suggestions/SuggestionsServices.cs
@@ -1,0 +1,144 @@
+﻿using Library.Data;
+using Library.DTO.Books;
+using Library.DTO.Suggestions;
+using Library.Services.Auth.Users; 
+using Microsoft.EntityFrameworkCore;
+
+namespace Library.Services.Suggestions
+{
+    public class SuggestionsService : ISuggestionsService
+    {
+        private readonly LibraryDbContext _db;
+        private readonly ICurrentUserService _currentUser;
+
+        
+        private const double Alpha = 0.4;
+        private const double Beta  = 0.3;
+        private const double Gamma = 0.3;
+
+        public SuggestionsService(LibraryDbContext db, ICurrentUserService currentUser)
+        {
+            _db = db;
+            _currentUser = currentUser;
+        }
+
+        public async Task<IReadOnlyList<SuggestionListItem>> SuggestionsAsync(int top = 10, CancellationToken ct = default)
+        {
+            var userId = _currentUser.GetCurrentUserId();
+
+            var readBookIds = await _db.Loan
+                .AsNoTracking()
+                .Where(l => l.UserId == userId)
+                .Select(l => l.BookId)
+                .Distinct()
+                .ToListAsync(ct);
+
+            string? frequentAuthor = null;
+            Guid? frequentCategoryId = null;
+            int? avgYear = null;
+
+            if (readBookIds.Count > 0)
+            {
+                frequentAuthor = await _db.Book
+                    .AsNoTracking()
+                    .Where(b => readBookIds.Contains(b.Id))
+                    .GroupBy(b => b.Author)
+                    .OrderByDescending(g => g.Count())
+                    .Select(g => g.Key)
+                    .FirstOrDefaultAsync(ct);
+
+                frequentCategoryId = await _db.Book
+                    .AsNoTracking()
+                    .Where(b => readBookIds.Contains(b.Id))
+                    .GroupBy(b => b.CategoryId)
+                    .OrderByDescending(g => g.Count())
+                    .Select(g => g.Key)
+                    .FirstOrDefaultAsync(ct);
+
+                avgYear = await _db.Book
+                    .AsNoTracking()
+                    .Where(b => readBookIds.Contains(b.Id))
+                    .AverageAsync(b => (double)b.PublicationYear, ct)
+                    .ContinueWith(t => (int)Math.Round(t.Result), ct);
+            }
+
+            var popularityRaw = await _db.Loan
+                .AsNoTracking()
+                .GroupBy(l => l.BookId)
+                .Select(g => new { BookId = g.Key, C = g.Count() })
+                .ToListAsync(ct);
+
+            var popDict = popularityRaw.ToDictionary(x => x.BookId, x => x.C);
+            var maxLoans = popularityRaw.Count > 0 ? popularityRaw.Max(x => x.C) : 0;
+
+            var candidates = await _db.Book
+                .AsNoTracking()
+                .Include(b => b.Category)
+                .Where(b => !readBookIds.Contains(b.Id))
+                .ToListAsync(ct);
+
+            var ranked = candidates
+                .Select(b => new
+                {
+                    Book = b,
+                    Score = CalcScore(
+                        book: b,
+                        frequentAuthor,
+                        frequentCategoryId,
+                        avgYear,
+                        maxLoans,
+                        popDict.TryGetValue(b.Id, out var cnt) ? cnt : 0
+                    )
+                })
+                .OrderByDescending(x => x.Score)
+                .ThenBy(x => x.Book.Title)
+                .Take(top)
+                .Select(x => new SuggestionListItem()
+                {
+                    Id = x.Book.Id,
+                    Title = x.Book.Title,
+                    Author = x.Book.Author,
+                    Category = x.Book.Category.Name,
+                    PublicationYear = x.Book.PublicationYear,
+                    Score = Math.Round(x.Score, 4)
+                })
+                .ToList();
+
+            return ranked;
+        }
+
+        private static double CalcScore(
+            Book book,
+            string? prefAuthor,
+            Guid? prefCategoryId,
+            int? avgYear,
+            int maxLoansGlobal,
+            int loansOfBook
+        )
+        {
+            double simAuthor = (!string.IsNullOrWhiteSpace(prefAuthor) && book.Author == prefAuthor) ? 1.0 : 0.0;
+            double simCategory = (prefCategoryId.HasValue && book.CategoryId == prefCategoryId.Value) ? 1.0 : 0.0;
+
+            double simYear = 0.0;
+            if (avgYear.HasValue)
+            {
+                var d = Math.Min(10, Math.Abs(book.PublicationYear - avgYear.Value));
+                simYear = 1.0 - (d / 10.0); // [0,1]
+            }
+
+            double hasPrefs = (avgYear.HasValue || !string.IsNullOrWhiteSpace(prefAuthor) || prefCategoryId.HasValue) ? 1.0 : 0.0;
+            double content = hasPrefs > 0 ? (simAuthor + simCategory + simYear) / 3.0 : 0.0;
+
+            // --- Popularidad (P) ---
+            double popularity = (maxLoansGlobal > 0) ? loansOfBook / (double)maxLoansGlobal : 0.0;
+
+            // --- Historial (H) ---
+            double history = content;
+
+            double s = (Alpha * content) + (Beta * popularity) + (Gamma * history);
+            if (s < 0) s = 0;
+            if (s > 1) s = 1;
+            return s;
+        }
+    }
+}


### PR DESCRIPTION
- Introduced `SuggestionsService` and `ISuggestionsService` with scoring logic for personalized book recommendations.
- Added `SuggestionsController` with an endpoint to fetch top suggestions based on user reading history.
- Created DTOs `SuggestionListItem` and `SuggestionsResponse` for structured responses.
- Updated `Program.cs` for DI of `SuggestionsService` and seed data initialization.
- Implemented `DataSeeder` methods to populate categories and books.
- Removed outdated `UsersRequest` and `UsersResponse` DTOs.