### PR TITLE
feat: update LogWorker service configuration and add Metrics reference

### DIFF
--- a/.idea/.idea.Library/Docker/docker-compose.generated.override.yml
+++ b/.idea/.idea.Library/Docker/docker-compose.generated.override.yml
@@ -30,7 +30,7 @@ services:
     - "/app/bin/Debug/net8.0/LogWorker.dll"
     environment:
       DOTNET_ENVIRONMENT: "Development"
-    image: "logworker:dev"
+    image: "luxwise/log-worker:dev"
     ports: []
     volumes:
     - "C:\\Users\\sanch\\source\\repos\\Library\\LogWorker:/app:rw"

--- a/LogWorker/LogWorker.csproj
+++ b/LogWorker/LogWorker.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+    <ProjectReference Include="..\Metrics\Metrics.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,8 @@
         condition: service_healthy
         
   log-worker:
+    image: luxwise/log-worker:latest
+    container_name: log_worker
     build:
       context: .                 
       dockerfile: ./LogWorker/Dockerfile


### PR DESCRIPTION
- Updated `docker-compose.yaml`:
  - Added `log-worker` service with new image tags (`luxwise/log-worker:latest` and `luxwise/log-worker:dev`).
  - Set container name to `log_worker`.
- Updated `LogWorker.csproj` to include project reference to `Metrics`.