### PR TITLE
refactor: rename Logs namespace to LogsBackground and update Dockerfile

### DIFF
--- a/LogWorker/Dockerfile
+++ b/LogWorker/Dockerfile
@@ -1,22 +1,19 @@
+# build
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
-# Copiamos csproj primero para cachear restore
 COPY ./Metrics/Metrics.csproj ./Metrics/
 COPY ./LogWorker/LogWorker.csproj ./LogWorker/
 
 RUN dotnet restore ./LogWorker/LogWorker.csproj
 
-# Copiamos el resto del código
 COPY ./Metrics/ ./Metrics/
 COPY ./LogWorker/ ./LogWorker/
 
-# DEBUG: asegurar que el archivo está en el contexto y con el casing correcto
-RUN test -f ./LogWorker/Logs/LogOptions.cs || (echo "❌ NO se encontró LogWorker/Logs/LogOptions.cs" && ls -la ./LogWorker && ls -la ./LogWorker/Logs && exit 1)
-
 RUN dotnet publish ./LogWorker/LogWorker.csproj -c $BUILD_CONFIGURATION -o /app
 
+# runtime
 FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime
 WORKDIR /app
 COPY --from=build /app .

--- a/LogWorker/LogsBackground/LogOptions.cs
+++ b/LogWorker/LogsBackground/LogOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace LogWorker.Logs;
+﻿namespace LogWorker.LogsBackground;
 
 public class LogOptions
 {

--- a/LogWorker/Program.cs
+++ b/LogWorker/Program.cs
@@ -1,4 +1,4 @@
-using LogWorker.Logs;
+using LogWorker.LogsBackground;
 using LogWorker.Services;
 using Metrics.Data;
 using Microsoft.EntityFrameworkCore;

--- a/LogWorker/Services/LogIngestionBackgroundService.cs
+++ b/LogWorker/Services/LogIngestionBackgroundService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.RegularExpressions;
-using LogWorker.Logs;
+using LogWorker.LogsBackground;
 using Microsoft.Extensions.Options;
 using Metrics.Data;
 using Metrics.Model;


### PR DESCRIPTION
- Replaced `LogWorker.Logs` with `LogWorker.LogsBackground` across affected files.
- Adjusted Dockerfile to remove outdated debugging step and optimize build process.